### PR TITLE
Ignore comments

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -15,7 +15,7 @@ interface CommentSection {
     end: number
 }
 const removeComments = (original: string) => {
-    const limits = original.matchAll(/\(\*|\*\)/gm);
+    const limits = original.matchAll(/\(\*|\*\)|"/gm);
     const template = {
         level: 0,
         start: 0,
@@ -23,12 +23,16 @@ const removeComments = (original: string) => {
     };
     let current = { ...template };
     const commentofs: CommentSection[] = [];
+    let inQuote = false;
     for (const l of limits) {
-        if (l[0] === "(*" && l.index !== undefined) {
+        if (l[0] === `"` && l.index !== undefined && current.level === 0 && original.substr(l.index - 1, 1) !== `\\`) {
+            inQuote = !inQuote;
+        }
+        if (l[0] === "(*" && l.index !== undefined && !inQuote) {
             current.level += 1;
             if (current.level === 1) { current.start = l.index; };
         }
-        else if (l[0] === "*)" && l.index !== undefined) {
+        else if (l[0] === "*)" && l.index !== undefined && !inQuote) {
             current.level -= 1;
             if (current.level === 0) {
                 current.end = l.index + 2;

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -2,9 +2,54 @@ import * as vscode from 'vscode';
 
 import { getFirstState, interpret, InterpreterOptions, PrintOptions, Errors, State } from '@sosml/interpreter';
 import * as fs from 'fs';
-import * as path from 'path';
 import { normalize } from 'path';
 
+declare global {
+    interface String {
+        splitMlCode(): string[];
+    }
+}
+interface CommentSection {
+    level: number,
+    start: number,
+    end: number
+}
+const removeComments = (original: string) => {
+    const limits = original.matchAll(/\(\*|\*\)/gm);
+    const template = {
+        level: 0,
+        start: 0,
+        end: 0
+    };
+    let current = { ...template };
+    const commentofs: CommentSection[] = [];
+    for (const l of limits) {
+        if (l[0] === "(*" && l.index !== undefined) {
+            current.level += 1;
+            if (current.level === 1) { current.start = l.index; };
+        }
+        else if (l[0] === "*)" && l.index !== undefined) {
+            current.level -= 1;
+            if (current.level === 0) {
+                current.end = l.index + 2;
+                commentofs.unshift(current);
+                current = { ...template };
+            }
+        };
+    }
+    let uncommented = original;
+    for (const cof of commentofs) {
+        const prefix = uncommented.substr(0, cof.start - 1);
+        const suffix = uncommented.substr(cof.end);
+        uncommented = `${prefix}${suffix}`;
+    }
+    return uncommented;
+};
+
+String.prototype.splitMlCode = function () {
+    let original = String(this);
+    return removeComments(original).split(';');
+};
 export class SMLView {
 
     public static currentView: SMLView | undefined;
@@ -101,7 +146,7 @@ export class SMLView {
         let preloadedUserFunctionsOutput = _evaluateProgram(preloadedUserFunctions, interpreter);
 
         let preloadedUserFunctionsHTML = (preloadedUserFunctionsOutput !== "") ? ('<button class=collapsible>Preloaded User Functions</button>' + `<div class=content>${preloadedUserFunctionsOutput
-            .split(';')
+            .splitMlCode()
             .filter(x => x !== '\n')
             .map((x) => { if (!(x.startsWith('There was a problem with your code:'))) { return x + ';'; } else { return x; } })
             .reduce((prev, current) => { return prev + current + '</p>'; }, '<p>')
@@ -115,7 +160,7 @@ export class SMLView {
         let importedCodeOutput = _evaluateProgram(importedCode, interpreter);
 
         let importedCodeHTML = (importedCodeOutput !== "") ? ('<button class=collapsible>Imported Code</button>' + `<div class=content>${importedCodeOutput
-            .split(';')
+            .splitMlCode()
             .filter(x => x !== '\n')
             .map((x) => { if (!(x.startsWith('There was a problem with your code:'))) { return x + ';'; } else { return x; } })
             .reduce((prev, current) => { return prev + current + '</p>'; }, '<p>')
@@ -124,7 +169,7 @@ export class SMLView {
 
         let smlResult = documentText
             .replace(/[\n\r]/g, '\n')
-            .split(';')
+            .splitMlCode()
             .map((program) => _evaluateProgram(program + ';', interpreter));
 
         let styleSheet = `<style> \
@@ -166,7 +211,7 @@ for (i = 0; i < coll.length; i++) {
                     const start = program.startsWith('There was a problem with your code:') ?
                         `<div class="div-error">` : `<div class="div-${index % 5}">`;
                     return start + program
-                        .split(';')
+                        .splitMlCode()
                         .filter(x => x !== '\n')
                         .map((x) => { if (!(x.startsWith('There was a problem with your code:'))) { return x + ';'; } else { return x; } })
                         .reduce((prev, current) => { return prev + current + '</p>'; }, '<p>')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
 		"target": "ES6",
 		"outDir": "out",
 		"lib": [
-			"es6"
+			"es6",
+			"ES2020.String"
 		],
 		"sourceMap": true,
 		"rootDir": "src",


### PR DESCRIPTION
Hi, this fixes an issue with comments containing ";"

The following program would fail without this change:
```ml
(*;*)
val a = 1
```
To make things easier I simply remove the comments before splitting. Added a string method to limit the changes to existing code

PS: would be easier and more robust to just pass the whole string, but I do see the appeal of the rainbow

Best regards
Marcello