### PR TITLE
ignore ; in the middle of a function

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -50,9 +50,11 @@ const removeComments = (original: string) => {
     return uncommented;
 };
 
+
 String.prototype.splitMlCode = function () {
-    let original = String(this);
-    return removeComments(original).split(';');
+    const original = String(this);
+    const nocomments = removeComments(original);
+    return nocomments.split(/\;[\n\s]*(?=\n[^\s])/gm);
 };
 export class SMLView {
 
@@ -215,7 +217,7 @@ for (i = 0; i < coll.length; i++) {
                     const start = program.startsWith('There was a problem with your code:') ?
                         `<div class="div-error">` : `<div class="div-${index % 5}">`;
                     return start + program
-                        .splitMlCode()
+                        .split(";")
                         .filter(x => x !== '\n')
                         .map((x) => { if (!(x.startsWith('There was a problem with your code:'))) { return x + ';'; } else { return x; } })
                         .reduce((prev, current) => { return prev + current + '</p>'; }, '<p>')


### PR DESCRIPTION
Allows processing code like this:

```ml
fun foo bar =
        let val x = bar + 1 in
            print "foo!\n";
            print ("bar=" ^ Int.toString(bar) ^ "\n");
            bar + 1
        end
```
This is valid ml, but the bits you get splitting at ";" are not
The scary regex basically says "; but only if at end of line and the next non empty line has no leading spaces"
I think you can still fool it using {} instead of indentation as block delimiters, but I'm not even trying to fix that!
